### PR TITLE
add CaptchaService test

### DIFF
--- a/SunEngine.Tests/DefaultInit.cs
+++ b/SunEngine.Tests/DefaultInit.cs
@@ -1,4 +1,8 @@
-﻿using SunEngine.Core.DataBase;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SunEngine.Core.Configuration.Options;
+using SunEngine.Core.DataBase;
+using SunEngine.Core.Services;
 
 namespace SunEngine.Tests
 {
@@ -17,6 +21,18 @@ namespace SunEngine.Tests
         {
             LinqToDB.Common.Configuration.Linq.AllowMultipleQuery = true;
             return new DataBaseFactory(provider, connectionString, new DbMappingSchema());
+        }
+
+        public static ServiceProvider DefaultServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddOptions<IOptions<CacheOptions>>();
+
+            CryptService cryptService = new CryptService();
+            cryptService.AddCryptorKey(CaptchaService.CryptserviceName);
+
+            serviceCollection.AddSingleton(cryptService);
+            return serviceCollection.BuildServiceProvider();
         }
     }
 }

--- a/SunEngine.Tests/SunEngine.Core/Services/CaptchaServiceTest.cs
+++ b/SunEngine.Tests/SunEngine.Core/Services/CaptchaServiceTest.cs
@@ -1,0 +1,80 @@
+﻿using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SunEngine.Core.Configuration.Options;
+using SunEngine.Core.Services;
+using Xunit;
+
+namespace SunEngine.Tests.SunEngine.Core.Services
+{
+    public class CaptchaServiceTest
+    {
+        private ServiceProvider serviceProvider;
+        private CaptchaService captchaService;
+
+        public CaptchaServiceTest()
+        {
+            serviceProvider = DefaultInit.DefaultServiceProvider();
+            IOptions<CaptchaOptions> captchaOptions = serviceProvider.GetRequiredService<IOptions<CaptchaOptions>>();
+            var cryptService = serviceProvider.GetRequiredService<CryptService>();
+
+            captchaService = new CaptchaService(captchaOptions, cryptService);
+        }
+
+        [Fact]
+        public void ShouldMakeCryptedCaptchaToken()
+        {
+            string token = captchaService.MakeCryptedCaptchaToken();
+
+            Assert.NotNull(token);
+            Assert.NotEqual(string.Empty, token);
+        }
+
+        [Fact]
+        public void ShouldReturnTextFromToken()
+        {
+            string token = captchaService.MakeCryptedCaptchaToken();
+            string textFromToken = captchaService.GetTextFromToken(token);
+
+            Assert.NotNull(textFromToken);
+            Assert.NotEqual(string.Empty, textFromToken);
+        }
+
+        [Fact]
+        public void ShouldReturnTrueOnVerifyToken()
+        {
+            string token = captchaService.MakeCryptedCaptchaToken();
+            string textFromToken = captchaService.GetTextFromToken(token);
+            
+            Assert.True(captchaService.VerifyToken(token, textFromToken));
+        }
+
+        [Fact]
+        public void ShouldReturnFalseOnVerifyTokenWithInvalidText()
+        {
+            string token = captchaService.MakeCryptedCaptchaToken();
+            string textFromToken = string.Empty;
+
+            Assert.False(captchaService.VerifyToken(token, textFromToken));
+        }
+
+        [Fact]
+        public void ShouldReturnFalseOnVerifyTokenWithInvalidToken()
+        {
+            string token = captchaService.MakeCryptedCaptchaToken();
+            string textFromToken = captchaService.GetTextFromToken(token);
+
+            Assert.False(captchaService.VerifyToken(captchaService.MakeCryptedCaptchaToken(), textFromToken));
+        }
+
+        [Fact]
+        public void ShouldMakeCaptchaImage()
+        {
+            string text = "fghjt4Tjg";
+            MemoryStream ms = captchaService.MakeCaptchaImage(text);
+            
+            Assert.NotNull(ms);
+            ms.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Check this test. And I have one question. In Constructor CaptchaService we have first argument as IOptions<CaptchaOptions>, but it don't used. We need to make CaptchaOptions and fill it in the same json config or just remove this argument? 
Etc. Do we need on tests like this moq framework? cause this is integration test.