### PR TITLE
Sanitizer: allowed domens for img and refactor

### DIFF
--- a/SunEngine.Cli/Config/Sanitizer.json
+++ b/SunEngine.Cli/Config/Sanitizer.json
@@ -77,6 +77,9 @@
         "https://player.vimeo.com",
         "http://player.vimeo.com",
         "//player.vimeo.com"
+      ],
+      "AllowedImageDomains": [
+        
       ]
     }
   }

--- a/SunEngine.Core/Configuration/Options/SanitizerOptions.cs
+++ b/SunEngine.Core/Configuration/Options/SanitizerOptions.cs
@@ -13,5 +13,7 @@ namespace SunEngine.Core.Configuration.Options
         public string[] AllowedCssProperties { get; set; } = Array.Empty<string>();
         
         public string[] AllowedVideoDomains { get; set; } = Array.Empty<string>();
+
+        public string[] AllowedImageDomains { get; set; } = Array.Empty<string>();
     }
 }

--- a/SunEngine.Core/Services/Sanitizer.cs
+++ b/SunEngine.Core/Services/Sanitizer.cs
@@ -106,7 +106,7 @@ namespace SunEngine.Core.Services
                 new { Tag = "iframe", Attribute = "src", AllowedDomainsList = options.AllowedVideoDomains },
                 new { Tag = "img", Attribute = "src", AllowedDomainsList = options.AllowedImageDomains }
             };
-
+            
             var tagName = e.Tag.TagName.ToLower();
             var tag = checkingTags.FirstOrDefault(x => x.Tag == tagName);
             if (tag != null)

--- a/SunEngine.Core/Services/Sanitizer.cs
+++ b/SunEngine.Core/Services/Sanitizer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using AngleSharp.Dom.Html;
 using AngleSharp.Extensions;
@@ -61,24 +62,19 @@ namespace SunEngine.Core.Services
             htmlSanitizer.RemovingAttribute += OnRemovingAttribute;
         }
 
-        private bool CheckIframeAllowedDomens(string tagName, RemovingTagEventArgs e)
+        private bool CheckAllowedDomains(string attrName, IEnumerable<string> allowedDomains, RemovingTagEventArgs e)
         {
-            if (tagName == "iframe")
+            var src = e.Tag.GetAttribute(attrName).TrimStart().ToLower();
+            foreach (var allowedDomain in allowedDomains)
             {
-                var src = e.Tag.GetAttribute("src").TrimStart().ToLower();
-                foreach (var allowedDomen in options.AllowedVideoDomains)
+                if (src.StartsWith(allowedDomain))
                 {
-                    if (src.StartsWith(allowedDomen))
-                    {
-                        e.Cancel = true;
-                        return true;
-                    }
+                    e.Cancel = true;
+                    return true;
                 }
-
-                e.Cancel = false;
-                return true;
             }
 
+            e.Cancel = false;
             return false;
         }
 
@@ -105,8 +101,18 @@ namespace SunEngine.Core.Services
 
         private void OnRemovingTag(object sender, RemovingTagEventArgs e)
         {
+            var checkingTags = new[]
+            {
+                new { Tag = "iframe", Attribute = "src", AllowedDomainsList = options.AllowedVideoDomains },
+                new { Tag = "img", Attribute = "src", AllowedDomainsList = options.AllowedImageDomains }
+            };
+
             var tagName = e.Tag.TagName.ToLower();
-            CheckIframeAllowedDomens(tagName, e);
+            var tag = checkingTags.FirstOrDefault(x => x.Tag == tagName);
+            if (tag != null)
+            {
+                CheckAllowedDomains(tag.Attribute, tag.AllowedDomainsList, e);
+            }
         }
     }
 


### PR DESCRIPTION
**What`s new:**

You can set list an allowed domains for loading images in comments, themes, blogs, etc.
If you would allow loading from all domains, add img tag to allowed tags in Sanitizer.json

_______
**Changes are not relevant for this version of SunEngine!**
Task from trello